### PR TITLE
init command should run `fly machine api-proxy` for user

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -58,6 +58,18 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Ensure we can connect to Fly's API
+	if fly.ShouldStartFlyMachineApiProxy() {
+		_, err = fly.FindFlyctlCommandPath()
+
+		if err != nil {
+			logger.GetLogger().Error("command", "init", "msg", "could not find flyctl command", "error", err)
+			PrintIfVerbose(Verbose, err, "You need flyctl installed to make API calls to Fly.io")
+
+			os.Exit(1)
+		}
+	}
+
 	// Get/generate application name
 	dir, err := os.Getwd()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,14 +40,15 @@ func init() {
 // runInitCommand will guide users through setting up a new development environment.
 // It performs the following actions:
 //  1. Retrieves vessel configuration
-//  2. Helps create an environment name
-//  3. Prompts for dev env type (PHP, etc)
-//  4. Generates env files (SSH keys, etc)
-//  5. Gets user's nearest region
-//  6. Creates the dev environment
-//  7. Generates project and SSH configuration
-//  8. Downloads Mutagen (if needed)
-//  9. Waits for dev env to be available
+//  2. Starts `fly machine api-proxy` if needed
+//  3. Helps create an environment name
+//  4. Prompts for dev env type (PHP, etc)
+//  5. Generates env files (SSH keys, etc)
+//  6. Gets user's nearest region
+//  7. Creates the dev environment
+//  8. Generates project and SSH configuration
+//  9. Downloads Mutagen (if needed)
+//  10. Waits for dev env to be available
 func runInitCommand(cmd *cobra.Command, args []string) {
 	auth, err := config.RetrieveVesselConfig()
 
@@ -60,7 +61,7 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 
 	// Ensure we can connect to Fly's API
 	if fly.ShouldStartFlyMachineApiProxy() {
-		_, err = fly.FindFlyctlCommandPath()
+		flyctl, err := fly.FindFlyctlCommandPath()
 
 		if err != nil {
 			logger.GetLogger().Error("command", "init", "msg", "could not find flyctl command", "error", err)
@@ -68,6 +69,17 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 
 			os.Exit(1)
 		}
+
+		stopFlyctl, err := fly.StartMachineProxy(flyctl)
+
+		if err != nil {
+			logger.GetLogger().Error("command", "init", "msg", "could not run `flyctl machine api-proxy` command", "error", err)
+			PrintIfVerbose(Verbose, err, "Could not make API calls to Fly.io via api-proxy")
+
+			os.Exit(1)
+		}
+
+		defer stopFlyctl()
 	}
 
 	// Get/generate application name

--- a/internal/fly/api-proxy.go
+++ b/internal/fly/api-proxy.go
@@ -1,0 +1,65 @@
+package fly
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+)
+
+// ShouldStartFlyMachineApiProxy will attempt to run the `fly machine api-proxy` command
+// if FLY_HOST env var is not set and no connection to 127.0.0.1:4280 can be made (user
+// did not already start the machine api-proxy).
+func ShouldStartFlyMachineApiProxy() bool {
+	// If FLY_HOST is set, we do nothing, as we assume
+	// the user is VPNed into Fly and using _api.internal:4280
+	flyHost := os.Getenv("FLY_HOST")
+
+	if len(flyHost) > 0 {
+		flyApiHost = flyHost
+		return false
+	}
+
+	// Test if we can connect to the proxy address
+	conn, err := net.Dial("tcp", "127.0.0.1:4280")
+	if err != nil {
+		// If proxying is not happening unable to connect,
+		// we *should* attempt to start the proxy
+		return true
+	}
+	defer conn.Close()
+
+	// We were able to connect, user likely already has
+	// the machine api-proxy running
+	return false
+}
+
+// FindFlyctlCommandPath determines if Flyctl is installed
+// in the user's PATH
+func FindFlyctlCommandPath() (string, error) {
+	path, err := exec.LookPath("flyctl")
+
+	if err != nil {
+		return "", fmt.Errorf("could not find flyctl in PATH: %w", err)
+	}
+
+	return path, nil
+}
+
+// TODO: Need to start this in the background and stop it later
+//       Run it in a goroutine and have a function to stop it (how to stop it?)
+func StartMachineProxy() error {
+	proc := &exec.Cmd{
+		Path: "flyctl",
+		Args: []string{
+			"fyctl",
+			"machine",
+			"api-proxy",
+		},
+	}
+	return nil
+}
+
+func StopMachineProxy() error {
+	return nil
+}

--- a/internal/fly/docker.go
+++ b/internal/fly/docker.go
@@ -1,8 +1,0 @@
-package fly
-
-// In previous iteration, we manually exec'ed
-// `fly auth docker`, then `docker tag some-local-image registry.fly.io/$app:latest`,
-// and finally `docker push registry.fly.io/$app:latest`
-
-type PushToRegistryRequest struct {
-}


### PR DESCRIPTION
Resolving #5 

Ideally the user has `flyctl` installed (since they need it to either VPN into Fly and run the `fly machine api-proxy` command), so we'll try to run that command for users automatically.

That's much easier than forcing users to run that command themselves.

> The api-proxy is only needed for the `vessel init` command