### PR TITLE
Custom ignores

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/vessel-app/vessel-cli/internal/fly"
 	"github.com/vessel-app/vessel-cli/internal/logger"
 	"github.com/vessel-app/vessel-cli/internal/util"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -89,7 +88,7 @@ org: %s
 `, AuthToken, SelectedOrg.Name, SelectedOrg.Slug)
 
 	configPath := filepath.ToSlash(vesselDir + "/config.yml")
-	if err = ioutil.WriteFile(configPath, []byte(yaml), 0755); err != nil {
+	if err = os.WriteFile(configPath, []byte(yaml), 0755); err != nil {
 		logger.GetLogger().Error("command", "auth", "msg", "could not write vessel config file", "error", err)
 		PrintIfVerbose(Verbose, err, "could not set auth token")
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vessel-app/vessel-cli/internal/mutagen"
 	"github.com/vessel-app/vessel-cli/internal/remote"
 	"github.com/vessel-app/vessel-cli/internal/util"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -161,7 +160,7 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 	}
 
 	privateKeyPath := filepath.FromSlash(vesselAppDir + "/id_ed25519")
-	if err = ioutil.WriteFile(privateKeyPath, keys.Private, 0600); err != nil {
+	if err = os.WriteFile(privateKeyPath, keys.Private, 0600); err != nil {
 		logger.GetLogger().Error("command", "init", "msg", "could not store generated SSH private key", "error", err, "file", privateKeyPath)
 		PrintIfVerbose(Verbose, err, "error initializing app")
 		stopFlyctl()
@@ -169,7 +168,7 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 	}
 
 	publicKeyPath := filepath.FromSlash(vesselAppDir + "/id_ed25519.pub")
-	if err = ioutil.WriteFile(publicKeyPath, keys.Public, 0644); err != nil {
+	if err = os.WriteFile(publicKeyPath, keys.Public, 0644); err != nil {
 		logger.GetLogger().Error("command", "init", "msg", "could not store generated SSH public key", "error", err, "file", publicKeyPath)
 		PrintIfVerbose(Verbose, err, "error initializing app")
 		stopFlyctl()

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -16,6 +16,7 @@ type EnvironmentConfig struct {
 	Image      string       `yaml:"image"`
 	Remote     RemoteConfig `yaml:"remote"`
 	Forwarding []string     `yaml:"forwarding"`
+	Ignore     []string     `yaml:"ignore"`
 }
 
 type RemoteConfig struct {

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -12,7 +12,7 @@ import (
 
 // RetrieveProjectConfig will find and parse a vessel.yml file for a given project
 func RetrieveProjectConfig(path string) (*EnvironmentConfig, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not read yaml file '%s': %w", path, err)
@@ -43,7 +43,7 @@ func RetrieveVesselConfig() (*AuthConfig, error) {
 	}
 
 	configPath := filepath.ToSlash(home + "/.vessel/config.yml")
-	file, err := ioutil.ReadFile(configPath)
+	file, err := os.ReadFile(configPath)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not read yaml file '%s': %w", configPath, err)
@@ -68,7 +68,7 @@ func RetrieveFlyConfig() (*FlyConfig, error) {
 	}
 
 	configPath := filepath.ToSlash(home + "/.fly/config.yml")
-	file, err := ioutil.ReadFile(configPath)
+	file, err := os.ReadFile(configPath)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not read yaml file '%s': %w", configPath, err)

--- a/internal/mutagen/start.go
+++ b/internal/mutagen/start.go
@@ -7,7 +7,7 @@ import (
 )
 
 func StartSession(name, localDir string, cfg *config.EnvironmentConfig) error {
-	_, err := Sync(name, cfg.Remote.Alias, localDir, cfg.Remote.RemotePath)
+	_, err := Sync(name, cfg.Remote.Alias, localDir, cfg.Remote.RemotePath, cfg.Ignore)
 
 	if err != nil {
 		return fmt.Errorf("error starting syncing: %w", err)

--- a/internal/remote/connection.go
+++ b/internal/remote/connection.go
@@ -7,7 +7,6 @@ import (
 	"github.com/vessel-app/vessel-cli/internal/config"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -39,7 +38,7 @@ func (c *Connection) clientConfig() (*ssh.ClientConfig, error) {
 		sshKey = c.config.IdentityFile
 	}
 
-	key, err := ioutil.ReadFile(sshKey)
+	key, err := os.ReadFile(sshKey)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read private key: %w", err)
 	}

--- a/internal/util/storage.go
+++ b/internal/util/storage.go
@@ -41,15 +41,50 @@ func MakeStorageDir() (string, error) {
 	return vesselPath, nil
 }
 
-// MakeAppDir creates a ~/.vessel/<app-name> directory
-func MakeAppDir(appName string) (string, error) {
-	vesselPath, err := MakeStorageDir()
+// MakeEnvStorageDir creates a ~/.vessel/envs directory
+func MakeEnvStorageDir() (string, error) {
+	home, err := homedir.Dir()
 
 	if err != nil {
-		return "", fmt.Errorf("could not create vessel storage dir: %w", err)
+		return "", fmt.Errorf("could not find home dir: %w", err)
 	}
 
-	vesselAppPath := filepath.FromSlash(vesselPath + "/" + appName)
+	vesselPath := filepath.FromSlash(home + "/.vessel/envs")
+
+	// Check if the ~/.vessel/envs directory exists already
+	// We assume a home directory always exists
+	stat, err := os.Stat(vesselPath)
+
+	if err == nil && stat.IsDir() {
+		// path exists already
+		return vesselPath, nil
+	} else if err == nil && !stat.IsDir() {
+		// path exists but is not a directory
+		return "", fmt.Errorf("could not create directory ~/.vessel/envs as a file with that name already exists")
+	} else if os.IsNotExist(err) {
+		// path does not exist, create it
+		if err := os.Mkdir(vesselPath, 0750); err != nil {
+			return "", fmt.Errorf("could not create vessel envs directory: %w", err)
+		}
+
+		return vesselPath, nil
+	} else if err != nil {
+		return "", fmt.Errorf("stat error: %w", err)
+	}
+
+	return vesselPath, nil
+}
+
+// MakeAppDir creates a ~/.vessel/<app-name> directory
+func MakeAppDir(appName string) (string, error) {
+	_, err := MakeStorageDir()
+	vesselEnvsPath, err := MakeEnvStorageDir()
+
+	if err != nil {
+		return "", fmt.Errorf("could not create vessel envs dir: %w", err)
+	}
+
+	vesselAppPath := filepath.FromSlash(vesselEnvsPath + "/" + appName)
 
 	stat, err := os.Stat(vesselAppPath)
 

--- a/internal/vessel/api.go
+++ b/internal/vessel/api.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/vessel-app/vessel-cli/internal/logger"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -112,7 +112,7 @@ func CreateEnvironment(team, name, publicKey, region, token string) (*Environmen
 	defer r.Body.Close()
 
 	if r.StatusCode > 299 {
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		logger.GetLogger().Debug("caller", "api::CreateEnvironment", "msg", "http request error", "status", r.StatusCode, "body", string(b))
 		return nil, fmt.Errorf("invalid create environment request: %w", err)
 	}


### PR DESCRIPTION
Resolves #4 

This PR does a few things, because mixing concerns is fun.

1. Resolved some depreciations
2. Changed environment files (SSH keys) to be stored in `~/.vessel/envs/<app-name>` instead of in `~/.vessel/<app-name>`
3. Made ignored directories customizable in `vessel.yml` via `ignore:` (example below)
4. If an image is used that includes the string `"php"`,  then we ignore `node_modules` and `vendor`
    - Eventually we'll abstract this so the images Vessel knows about will have meta data associated with it, such as ignores, forwards, and startup commands

New yaml section in application's `vessel.yml` file:

```yaml
ignore:
  - vendor
  - node_modules
  - foo
  - bar
```