### PR TITLE
ability to destroy dev environment and generated files

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/gosimple/slug"
+	"github.com/spf13/cobra"
+	"github.com/vessel-app/vessel-cli/internal/config"
+	"github.com/vessel-app/vessel-cli/internal/fly"
+	"github.com/vessel-app/vessel-cli/internal/logger"
+	"github.com/vessel-app/vessel-cli/internal/mutagen"
+	"github.com/vessel-app/vessel-cli/internal/util"
+	"os"
+	"time"
+)
+
+var destroyCmd = &cobra.Command{
+	Use:   "destroy",
+	Short: "Destroy a dev environment",
+	Long:  `Delete the development environment and related local Vessel files`,
+	Run:   runDestroyCommand,
+}
+
+var localFiles bool
+
+func init() {
+	destroyCmd.Flags().BoolVarP(&localFiles, "files-only", "f", false, "Only delete local files, not the virtual machine")
+	destroyCmd.Flags().StringVarP(&ConfigPath, "config-file", "c", "vessel.yml", "Configuration file to read from")
+}
+
+func runDestroyCommand(cmd *cobra.Command, args []string) {
+	cfg, err := config.RetrieveProjectConfig(ConfigPath)
+
+	if err != nil {
+		logger.GetLogger().Error("command", "destroy", "msg", "could not read configuration", "error", err)
+		PrintIfVerbose(Verbose, err, "error reading project configuration file")
+
+		os.Exit(1)
+	}
+
+	auth, err := config.RetrieveVesselConfig()
+
+	if err != nil {
+		logger.GetLogger().Error("command", "destroy", "msg", "could not get Fly API token from vessel config", "error", err)
+		PrintIfVerbose(Verbose, err, "error retrieving Fly API token")
+
+		os.Exit(1)
+	}
+
+	// Get mutagen session name
+	name := slug.Make("vessel-" + cfg.Name)
+
+	// Attempt to stop any currently running session
+	// Note that we ignore errors
+	mutagen.StopSession(name)
+
+	/**
+	 * The Process:
+	 * 1. Delete Fly App (which deletes machines, etc)
+	 * 2. vessel.yml
+	 * 3. ~/.vessel/envs/<app-name>
+	 * 4. Warn about ~/.ssh/config entries (TODO: Can we safely delete from that file?)
+	 */
+
+	stopFlyctl := func() error {
+		return nil
+		// Does nothing, but we want it to exist, so we can call it later
+		// even if we fly.ShouldStartFlyMachineApiProxy() == false
+	}
+
+	// Delete the VM if the -f / --files-only flag is not used
+	// This lets you delete the VM from within Fly's and then cleanup Vessel-generated files
+	if !localFiles {
+		// Ensure we can connect to Fly's API
+		if fly.ShouldStartFlyMachineApiProxy() {
+			flyctl, err := fly.FindFlyctlCommandPath()
+
+			if err != nil {
+				logger.GetLogger().Error("command", "init", "msg", "could not find flyctl command", "error", err)
+				PrintIfVerbose(Verbose, err, "You need flyctl installed to make API calls to Fly.io")
+
+				os.Exit(1)
+			}
+
+			// Create this var, allowing us to use = instead of := in assignment below it
+			// which ensures we are actually re-assigning the stopFlyctl variable
+			var proxyErr error
+			stopFlyctl, proxyErr = fly.StartMachineProxy(flyctl)
+			time.Sleep(time.Second * 2) // Give the proxy time to boot up
+
+			if proxyErr != nil {
+				logger.GetLogger().Error("command", "init", "msg", "could not run `flyctl machine api-proxy` command", "error", err)
+				PrintIfVerbose(Verbose, err, "Could not make API calls to Fly.io via api-proxy")
+
+				os.Exit(1)
+			}
+
+			defer stopFlyctl()
+		}
+
+		err = fly.DeleteApp(auth.Token, name)
+
+		if err != nil {
+			logger.GetLogger().Error("command", "destroy", "msg", "could not destroy Fly app", "error", err)
+			PrintIfVerbose(Verbose, err, "could not destroy Fly app")
+			stopFlyctl()
+
+			os.Exit(1)
+		}
+	}
+
+	err = os.Remove(ConfigPath)
+
+	if err != nil {
+		logger.GetLogger().Error("command", "destroy", "msg", "could not remove vessel project config file", "error", err)
+		PrintIfVerbose(Verbose, err, "could not delete project's vessel.yml file")
+		stopFlyctl()
+
+		os.Exit(1)
+	}
+
+	appEnvDir, err := util.GetAppEnvDir(name)
+
+	if err != nil {
+		logger.GetLogger().Error("command", "destroy", "msg", "could not find dev environment files", "error", err)
+		PrintIfVerbose(Verbose, err, "could not find dev environment files in ~/.vessel/envs")
+		stopFlyctl()
+
+		os.Exit(1)
+	}
+
+	err = os.RemoveAll(appEnvDir)
+
+	if err != nil {
+		logger.GetLogger().Error("command", "destroy", "msg", "could not delete dev environment files", "error", err)
+		PrintIfVerbose(Verbose, err, "could not delete dev environment files in ~/.vessel/envs")
+		stopFlyctl()
+
+		os.Exit(1)
+	}
+
+	fmt.Println("\033[1;32m\xE2\x9C\x94\033[0m Dev environment deleted")
+	fmt.Printf("\033[0;33mNote:\033[0m There likely is still an entry for `vessel-%s` in your ~/.ssh/config file\n", name)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ func Execute() {
 		sshCmd,
 		startCmd,
 		stopCmd,
+		destroyCmd,
 	}
 
 	rootCmd.Version = Version

--- a/internal/util/storage.go
+++ b/internal/util/storage.go
@@ -75,7 +75,17 @@ func MakeEnvStorageDir() (string, error) {
 	return vesselPath, nil
 }
 
-// MakeAppDir creates a ~/.vessel/<app-name> directory
+func GetAppEnvDir(appName string) (string, error) {
+	home, err := homedir.Dir()
+
+	if err != nil {
+		return "", fmt.Errorf("could not find home dir: %w", err)
+	}
+
+	return filepath.FromSlash(fmt.Sprintf("%s/envs/%s", home, appName)), nil
+}
+
+// MakeAppDir creates a ~/.vessel/envs/<app-name> directory
 func MakeAppDir(appName string) (string, error) {
 	_, err := MakeStorageDir()
 	vesselEnvsPath, err := MakeEnvStorageDir()


### PR DESCRIPTION
Resolves #12 

Ability to destroy the created Fly App (and Machine VM), along with vessel-generated files.

It does not remove entries from `~/.ssh/config` currently.

