### PR TITLE
Check more rigorously that API proxy launched successfully

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/gosimple/slug"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -10,8 +12,6 @@ import (
 	"github.com/vessel-app/vessel-cli/internal/logger"
 	"github.com/vessel-app/vessel-cli/internal/mutagen"
 	"github.com/vessel-app/vessel-cli/internal/util"
-	"os"
-	"time"
 )
 
 var destroyCmd = &cobra.Command{
@@ -98,13 +98,7 @@ func runDestroyCommand(cmd *cobra.Command, args []string) {
 				os.Exit(1)
 			}
 
-			// Create this var, allowing us to use = instead of := in assignment below it
-			// which ensures we are actually re-assigning the stopFlyctl variable
-			var proxyErr error
-			stopFlyctl, proxyErr = fly.StartMachineProxy(flyctl)
-			time.Sleep(time.Second * 2) // Give the proxy time to boot up
-
-			if proxyErr != nil {
+			if stopFlyctl, err = fly.StartMachineProxy(flyctl); err != nil {
 				logger.GetLogger().Error("command", "init", "msg", "could not run `flyctl machine api-proxy` command", "error", err)
 				PrintIfVerbose(Verbose, err, "Could not make API calls to Fly.io via api-proxy")
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/gernest/wow"
 	"github.com/gernest/wow/spin"
 	"github.com/gosimple/slug"
@@ -15,10 +20,6 @@ import (
 	"github.com/vessel-app/vessel-cli/internal/mutagen"
 	"github.com/vessel-app/vessel-cli/internal/remote"
 	"github.com/vessel-app/vessel-cli/internal/util"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 var initCmd = &cobra.Command{
@@ -76,13 +77,7 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		// Create this var, allowing us to use = instead of := in assignment below it
-		// which ensures we are actually re-assigning the stopFlyctl variable
-		var proxyErr error
-		stopFlyctl, proxyErr = fly.StartMachineProxy(flyctl)
-		time.Sleep(time.Second * 2) // Give the proxy time to boot up
-
-		if proxyErr != nil {
+		if stopFlyctl, err = fly.StartMachineProxy(flyctl); err != nil {
 			logger.GetLogger().Error("command", "init", "msg", "could not run `flyctl machine api-proxy` command", "error", err)
 			PrintIfVerbose(Verbose, err, "Could not make API calls to Fly.io via api-proxy")
 

--- a/internal/fly/api-proxy.go
+++ b/internal/fly/api-proxy.go
@@ -1,11 +1,15 @@
 package fly
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
+	"time"
 )
 
 // ShouldStartFlyMachineApiProxy will attempt to run the `fly machine api-proxy` command
@@ -21,18 +25,7 @@ func ShouldStartFlyMachineApiProxy() bool {
 		return false
 	}
 
-	// Test if we can connect to the proxy address
-	conn, err := net.Dial("tcp", "127.0.0.1:4280")
-	if err != nil {
-		// If proxying is not happening unable to connect,
-		// we *should* attempt to start the proxy
-		return true
-	}
-	defer conn.Close()
-
-	// We were able to connect, user likely already has
-	// the machine api-proxy running
-	return false
+	return !isProxyRunning(false)
 }
 
 // FindFlyctlCommandPath determines if Flyctl is
@@ -59,8 +52,21 @@ func StartMachineProxy(exe string) (func() error, error) {
 		},
 	}
 
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve stderr for machine api-proxy: %w", err)
+	}
+
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("could not start machine api-proxy: %w", err)
+	}
+
+	if !isProxyRunning(true) {
+		proxyStderrRaw, err := io.ReadAll(stderr)
+		if err != nil {
+			return nil, errors.New("could not start machine api-proxy")
+		}
+		return nil, fmt.Errorf("could not start machine api-proxy: %s", strings.TrimSpace(string(proxyStderrRaw)))
 	}
 
 	return func() error {
@@ -69,4 +75,29 @@ func StartMachineProxy(exe string) (func() error, error) {
 		}
 		return cmd.Process.Signal(os.Interrupt)
 	}, nil
+}
+
+// isProxyRunning determines if the fly machine API proxy is running by
+// attempting to open a TCP connection to the proxy port.
+func isProxyRunning(waitForStartup bool) bool {
+	connectFn := func() bool {
+		c, err := net.Dial("tcp", "127.0.0.1:4280")
+		if err != nil {
+			return false
+		}
+		defer c.Close()
+		return true
+	}
+	ok := connectFn()
+	if ok || !waitForStartup {
+		return ok
+	}
+	for i := 0; i < 10; i++ {
+		time.Sleep(200 * time.Millisecond)
+		if connectFn() {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This fixes a bug that causes vessel init to fail opaquely when it fails to launch the fly machine api-proxy command.

The previous implementation assumed that the api-proxy command succeeded as long as the command launches successfully, but that meant it wouldn't notice if the API proxy died with an error before it began serving.

This change adjusts the StartMachineProxy function so that it waits to return until it verifies a successful TCP connection to the API proxy. If it can't connect within 2 seconds, it attempts to return the stderr from the command as an error message.

This change also fixes related bugs in init.go and destroy.go where the callers were accidentally discarding the error return value from StartMachineProxy.