### PR TITLE
Fix error propagation mistake when testing SSH connection

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -356,7 +356,7 @@ forwarding:
 // (15 attempts, attempted every 2 seconds)
 func waitForConnection(connection *remote.Connection) error {
 	var err error
-	for attempts := 0; attempts <= 15; attempts++ {
+	for attempts := 0; attempts < 15; attempts++ {
 		if err = connection.TestConnection(); err != nil {
 			time.Sleep(2 * time.Second)
 		} else {


### PR DESCRIPTION
This fixes a bug where we were accidentally swallowing the error from TestConnection instead of printing it to the user. We were defining a new err variable with limited scope, but then later on, we tried to print its value even though at the point of printing, err referred to a different variable that was always nil.

This refactors the init code so that we print the error to the terminal and makes it harder to confuse different err variables.